### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/madeinoz67/bank-statement-separator/security/code-scanning/3](https://github.com/madeinoz67/bank-statement-separator/security/code-scanning/3)

To resolve this issue, we should explicitly add a `permissions` block to the workflow YAML file. This block can be set at the root level so all jobs inherit the permission settings unless overridden at the job level. An appropriate minimal starting point is `contents: read`, which allows the GITHUB_TOKEN only read access to repository contents. If a job needs more permissions (for example, uploading coverage results or artifacts), we may need to enable individual write permissions for those resources (such as `actions: write` for uploading artifacts or `pull-requests: write` for PR manipulation), but none of the current jobs appear to require write access beyond possibly uploading artifacts (which uses the artifact action, and does not require extra permissions for public repos). Therefore, the recommended fix is to add a root-level block:

```yaml
permissions:
  contents: read
```

This should be inserted after the `name` property and before the `on:` block (following standard conventions).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
