### PR TITLE
fix: enhance release workflow with debugging and improved PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release"
+        description: "Tag to release (e.g., v0.1.3)"
         required: true
         type: string
+      skip_pypi:
+        description: "Skip PyPI publishing (for testing)"
+        required: false
+        type: boolean
+        default: false
 
 # Prevent multiple releases for the same tag
 concurrency:
@@ -74,10 +79,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: release
-    if: needs.release.result == 'success' && ((github.event_name == 'push' && contains(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch')
+    if: needs.release.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && github.event.inputs.skip_pypi != 'true'
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Debug workflow context
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "Release job result: ${{ needs.release.result }}"
+          echo "Contains refs/tags: ${{ contains(github.ref, 'refs/tags/') }}"
+          echo "PYPI_API_TOKEN exists: ${{ secrets.PYPI_API_TOKEN != '' }}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -93,6 +106,19 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Publish to PyPI
+      - name: Verify package
         run: |
-          uv run twine upload dist/* --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
+          uv run twine check dist/*
+          ls -la dist/
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          if [ -z "$TWINE_PASSWORD" ]; then
+            echo "❌ PYPI_API_TOKEN secret is empty or not set"
+            exit 1
+          fi
+          echo "✅ PYPI_API_TOKEN is configured"
+          uv run twine upload dist/* --verbose

--- a/uv.lock
+++ b/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "bank-statement-separator"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Enhanced release workflow debugging to identify PyPI publishing issues
- Simplified job conditions from complex boolean logic to clear `startsWith()` checks
- Added comprehensive error handling for missing PYPI_API_TOKEN secret
- Improved package verification and verbose upload logging

## Changes Made
1. **Enhanced Debugging**: Added detailed workflow context output to identify execution issues
2. **Simplified Conditions**: Changed complex boolean conditions to `startsWith(github.ref, 'refs/tags/v')`  
3. **Better Error Handling**: Added explicit check for missing PYPI_API_TOKEN with clear error message
4. **Package Verification**: Added `twine check` validation before upload
5. **Verbose Logging**: Enhanced upload process with detailed logging for diagnostics

## Test Plan
- [ ] Test workflow trigger on tag push (e.g., `git tag v1.0.0 && git push origin v1.0.0`)
- [ ] Verify workflow dispatch functionality with manual trigger
- [ ] Confirm debugging output provides clear execution context
- [ ] Test error handling when PYPI_API_TOKEN is missing
- [ ] Validate package build and verification steps

Closes #9

🤖 Generated with Claude Code