### PR TITLE
fix: resolve PyPI publishing workflow condition issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: release
-    if: needs.release.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && github.event.inputs.skip_pypi != 'true'
+    if: needs.release.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && (github.event_name != 'workflow_dispatch' || github.event.inputs.skip_pypi != 'true')
 
     steps:
       - uses: actions/checkout@v4
@@ -91,6 +91,7 @@ jobs:
           echo "Release job result: ${{ needs.release.result }}"
           echo "Contains refs/tags: ${{ contains(github.ref, 'refs/tags/') }}"
           echo "PYPI_API_TOKEN exists: ${{ secrets.PYPI_API_TOKEN != '' }}"
+          echo "Skip PyPI input: ${{ github.event.inputs.skip_pypi || 'not-set' }}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
## Summary

Fixes GitHub issue #9: Release Workflow Not Publishing Package to PyPI

- Fixed publish job condition that was preventing PyPI publishing on tag triggers
- Condition was failing because `github.event.inputs.skip_pypi` doesn't exist for tag-triggered workflows
- Updated logic to only check `skip_pypi` input when workflow is manually dispatched

## Root Cause

The publish job condition had this logic:
```yaml
if: needs.release.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && github.event.inputs.skip_pypi != 'true'
```

When triggered by tag pushes, `github.event.inputs` is `null`, causing `github.event.inputs.skip_pypi != 'true'` to evaluate to `false`, preventing PyPI publishing.

## Solution

Updated the condition to:
```yaml
if: needs.release.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && (github.event_name != 'workflow_dispatch' || github.event.inputs.skip_pypi != 'true')
```

This ensures:
- Tag-triggered workflows: Only check release success and tag format
- Manual workflows: Additionally check the `skip_pypi` input
- PyPI publishing will execute for all valid tag pushes

## Test Plan

- [x] Local build and package verification passes (`./test_release.sh`)
- [x] All 144 unit tests pass
- [x] Package builds successfully and passes `twine check`
- [ ] Manual workflow dispatch test (after merge)
- [ ] Tag-triggered workflow test (on next release)

## Additional Changes

- Enhanced debug output to safely handle missing `skip_pypi` input with fallback value
- Improved workflow troubleshooting capabilities

## Validation

```bash
✅ All release workflow steps completed successfully!
📦 Package ready for PyPI publishing
================== 144 passed, 2 skipped, 5 warnings in 2.75s ==================
```

Closes #9