### PR TITLE
fix: resolve documentation formatting issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,5 +44,6 @@ repos:
           (?x)^(
               \.venv/.*|
               uv\.lock|
-              .*\.ipynb
+              .*\.ipynb|
+              docs/.*\.md
           )$

--- a/docs/design/PRD.md
+++ b/docs/design/PRD.md
@@ -5,8 +5,11 @@
 ---
 
 **Document Version:** 2.5
+
 **Date:** September 10, 2025
+
 **Author:** Stephen Eaton
+
 **Status:** Production Ready with Multi-Provider LLM Support & Input Document Processing Tracking
 
 ---

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -70,9 +70,15 @@ The system supports multiple LLM providers through a flexible abstraction layer:
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server URL |
 | `OLLAMA_MODEL`    | `llama3.2`               | Local model name  |
 
-!!! info "Provider Selection" - **openai**: Use OpenAI cloud models (requires API key) - **ollama**: Use local Ollama models (privacy-focused, no API costs) - **auto**: Automatically select best available provider
+!!! info "Provider Selection"
+    - **openai**: Use OpenAI cloud models (requires API key)
+    - **ollama**: Use local Ollama models (privacy-focused, no API costs)
+    - **auto**: Automatically select best available provider
 
-!!! tip "Model Selection" - `gpt-4o-mini`: Best balance of cost and performance (recommended) - `gpt-4o`: Highest accuracy, higher cost - `gpt-3.5-turbo`: Fastest, lower accuracy
+!!! tip "Model Selection"
+    - `gpt-4o-mini`: Best balance of cost and performance (recommended)
+    - `gpt-4o`: Highest accuracy, higher cost
+    - `gpt-3.5-turbo`: Fastest, lower accuracy
 
 ### Processing Configuration
 
@@ -135,7 +141,10 @@ For production deployments, always set `ALLOWED_INPUT_DIRS` and `ALLOWED_OUTPUT_
 | `REQUIRE_TEXT_CONTENT`    | `true`   | Require extractable text                        |
 | `MIN_TEXT_CONTENT_RATIO`  | `0.1`    | Minimum text content ratio                      |
 
-!!! info "Validation Strictness Levels" - **Strict**: All validation issues are errors (highest accuracy) - **Normal**: Balanced approach with warnings (recommended) - **Lenient**: Most issues are warnings (highest processing success rate)
+!!! info "Validation Strictness Levels"
+    - **Strict**: All validation issues are errors (highest accuracy)
+    - **Normal**: Balanced approach with warnings (recommended)
+    - **Lenient**: Most issues are warnings (highest processing success rate)
 
 ## Paperless-ngx Integration
 
@@ -488,9 +497,19 @@ Common environment file issues and solutions:
     sed -i 's/LOG_LEVEL=INVALID/LOG_LEVEL=INFO/' .env.test
     ```
 
-!!! tip "Environment File Best Practices" - **Never commit** `.env` files containing secrets to version control - **Use descriptive names** like `.env.dev`, `.env.prod` instead of generic names - **Document required variables** in each environment file header - **Test configurations** before deploying to production - **Use relative paths** where possible for portability - **Validate configurations** after changes using the validation script above
+!!! tip "Environment File Best Practices"
+    - **Never commit** `.env` files containing secrets to version control
+    - **Use descriptive names** like `.env.dev`, `.env.prod` instead of generic names
+    - **Document required variables** in each environment file header
+    - **Test configurations** before deploying to production
+    - **Use relative paths** where possible for portability
+    - **Validate configurations** after changes using the validation script above
 
-!!! warning "Security Considerations" - Production env files should be stored securely and access-controlled - Use different API keys for different environments - Set appropriate file permissions (644 or 600) - Never expose production credentials in development/test environments
+!!! warning "Security Considerations"
+    - Production env files should be stored securely and access-controlled
+    - Use different API keys for different environments
+    - Set appropriate file permissions (644 or 600)
+    - Never expose production credentials in development/test environments
 
 ### Environment Variable Precedence
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -2,7 +2,10 @@
 
 Get the Workflow Bank Statement Separator running in just 5 minutes!
 
-!!! info "Prerequisites" - Python 3.11+ - [UV package manager](https://docs.astral.sh/uv/) (recommended) - OpenAI API key (optional for testing)
+!!! info "Prerequisites"
+    - Python 3.11+
+    - [UV package manager](https://docs.astral.sh/uv/) (recommended)
+    - OpenAI API key (optional for testing)
 
 ## 1. Installation (2 minutes)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -210,7 +210,9 @@ This documentation is versioned to match software releases. Use the version sele
 - **Latest**: Always points to the most recent release documentation
 - **Versioned**: Access documentation for specific releases
 
-!!! info "Version URLs" - Latest: `https://madeinoz67.github.io/bank-statement-separator/` - Version 0.1.0: `https://madeinoz67.github.io/bank-statement-separator/v0.1.0/`
+!!! info "Version URLs"
+    - Latest: `https://madeinoz67.github.io/bank-statement-separator/`
+    - Version 0.1.0: `https://madeinoz67.github.io/bank-statement-separator/v0.1.0/`
 
 !!! tip "Finding Your Version"
 Check your installed version with: `uv run bank-statement-separator --version`
@@ -235,7 +237,14 @@ The MIT License is a permissive open-source license that allows you to:
 
 ## What's New
 
-!!! success "Latest Release: [Version 0.3.0](release_notes/RELEASE_NOTES_v0.3.0.md)" - **Error Detection & Tagging System**: Automatic identification and tagging of 6 types of processing errors - **Paperless Integration Enhancement**: Advanced document management with error flagging capabilities - **Configurable Error Handling**: Environment-based configuration with severity filtering and batch tagging - **Comprehensive Testing**: Complete test coverage including unit tests and manual testing scripts - **Enhanced Documentation**: Updated workflow diagrams and user guides for error detection features - **Performance Optimizations**: Improved boundary detection efficiency and code maintainability - **Backward Compatibility**: Full compatibility with existing workflows - error detection is optional
+!!! success "Latest Release: [Version 0.3.0](release_notes/RELEASE_NOTES_v0.3.0.md)"
+    - **Error Detection & Tagging System**: Automatic identification and tagging of 6 types of processing errors
+    - **Paperless Integration Enhancement**: Advanced document management with error flagging capabilities
+    - **Configurable Error Handling**: Environment-based configuration with severity filtering and batch tagging
+    - **Comprehensive Testing**: Complete test coverage including unit tests and manual testing scripts
+    - **Enhanced Documentation**: Updated workflow diagrams and user guides for error detection features
+    - **Performance Optimizations**: Improved boundary detection efficiency and code maintainability
+    - **Backward Compatibility**: Full compatibility with existing workflows - error detection is optional
 
     See full [Release Notes](release_notes/RELEASE_NOTES_v0.3.0.md) for detailed changes and [Changelog](release_notes/CHANGELOG.md) for complete version history.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -227,7 +227,7 @@ The error detection system identifies 6 types of processing errors:
 
 !!! example "Error Tagging Configuration"
 
-````bash # Basic error tagging setup
+```bash # Basic error tagging setup
 PAPERLESS_ERROR_DETECTION_ENABLED=true
 PAPERLESS_ERROR_TAGS=processing:needs-review,error:automated-detection
 PAPERLESS_ERROR_TAG_THRESHOLD=0.7
@@ -359,7 +359,7 @@ PRESERVE_FAILED_OUTPUTS=true
 DEVELOPMENT_MODE=true
 ENABLE_PROFILING=true
 MAX_RETRY_ATTEMPTS=1
-````
+```
 
 ### Testing Environment
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -21,7 +21,10 @@ Copy `.env.example` to `.env` to get started with documented default values for 
 | `LLM_MAX_TOKENS`             | Integer | `4000`        | Maximum tokens per API call                        |
 | `ENABLE_FALLBACK_PROCESSING` | Boolean | `true`        | Enable pattern-matching when AI fails              |
 
-!!! info "AI Model Selection" - `gpt-4o-mini`: Best balance of cost and performance (recommended) - `gpt-4o`: Highest accuracy, higher cost - `gpt-3.5-turbo`: Fastest processing, lower accuracy
+!!! info "AI Model Selection"
+    - `gpt-4o-mini`: Best balance of cost and performance (recommended)
+    - `gpt-4o`: Highest accuracy, higher cost
+    - `gpt-3.5-turbo`: Fastest processing, lower accuracy
 
 ### Text Processing
 
@@ -131,7 +134,10 @@ Always set `ALLOWED_INPUT_DIRS` and `ALLOWED_OUTPUT_DIRS` in production:
 | `MAX_FILE_AGE_DAYS`       | Integer | `365`    | Maximum age of input files                      |
 | `ALLOWED_FILE_EXTENSIONS` | List    | `.pdf`   | Allowed file extensions                         |
 
-!!! info "Validation Strictness Levels" - **Strict**: All validation issues cause processing to fail - **Normal**: Balance between validation and processing success - **Lenient**: Most validation issues generate warnings only
+!!! info "Validation Strictness Levels"
+    - **Strict**: All validation issues cause processing to fail
+    - **Normal**: Balance between validation and processing success
+    - **Lenient**: Most validation issues generate warnings only
 
 ### Content Validation
 
@@ -220,7 +226,8 @@ The error detection system identifies 6 types of processing errors:
     Only errors above the configured threshold and matching severity levels trigger automatic tagging.
 
 !!! example "Error Tagging Configuration"
-```bash # Basic error tagging setup
+
+````bash # Basic error tagging setup
 PAPERLESS_ERROR_DETECTION_ENABLED=true
 PAPERLESS_ERROR_TAGS=processing:needs-review,error:automated-detection
 PAPERLESS_ERROR_TAG_THRESHOLD=0.7
@@ -352,7 +359,7 @@ PRESERVE_FAILED_OUTPUTS=true
 DEVELOPMENT_MODE=true
 ENABLE_PROFILING=true
 MAX_RETRY_ATTEMPTS=1
-```
+````
 
 ### Testing Environment
 

--- a/uv.lock
+++ b/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "bank-statement-separator"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Fixed "What's New" section admonition block rendering issue on documentation front page
- Corrected admonition block list formatting across multiple documentation files
- Standardized PRD frontmatter formatting with proper spacing between metadata fields
- Added prettier exception for docs markdown files to prevent reformatting of admonition blocks

## Test plan
- [x] Verified online documentation renders admonition blocks properly instead of raw markdown
- [x] Checked that all admonition blocks now use proper indented list format
- [x] Confirmed PRD frontmatter displays correctly with proper line breaks
- [x] Validated that pre-commit hooks pass with prettier exception in place

## Files Changed
- `docs/index.md`: Fixed "What's New" and "Version URLs" admonition blocks
- `docs/getting-started/configuration.md`: Fixed multiple admonition blocks
- `docs/getting-started/quick-start.md`: Fixed prerequisites admonition block  
- `docs/reference/environment-variables.md`: Fixed model selection and validation admonition blocks
- `docs/design/PRD.md`: Fixed frontmatter formatting
- `.pre-commit-config.yaml`: Added prettier exception for docs markdown files

Fixes #29